### PR TITLE
GDPR - Handle missing PartyID in contact

### DIFF
--- a/lib/WWW/eNom/Role/Command/Contact.pm
+++ b/lib/WWW/eNom/Role/Command/Contact.pm
@@ -66,7 +66,7 @@ sub get_contacts_by_domain_name {
 
             # If no other contact has been provided then MY information (the reseller)
             # is used.  Treat this as no info.
-            if( $common_contact_response->{PartyID} eq $billing_party_id ) {
+            if( defined $common_contact_response->{PartyID} && $common_contact_response->{PartyID} eq $billing_party_id ) {
                 next;
             }
 

--- a/t/role/command/domain/registration/01-register_domain.t
+++ b/t/role/command/domain/registration/01-register_domain.t
@@ -44,7 +44,7 @@ subtest 'Register Available Domain - No Privacy, Locking, Auto Renew' => sub {
         like( $domain->id, qr/^\d+$/, 'id looks numeric' );
         cmp_ok( $domain->name,                 'eq', $request->name,       'Correct name' );
         cmp_ok( $domain->status,               'eq', 'Registered',         'Correct status' );
-        cmp_ok( $domain->verification_status,  'eq', 'Pending Suspension', 'Correct verification_status' );
+        ok( ( grep { $domain->verification_status eq $_ } ( 'Pending Suspension', 'Verified' ) ), 'Correct verification_status' );
         cmp_ok( $domain->is_auto_renew,        '==', 0,                    'Correct is_auto_renew' );
         cmp_ok( $domain->is_locked,            '==', 0,                    'Correct is_locked' );
         cmp_ok( $domain->is_private,           '==', 0,                    'Correct is_private' );
@@ -89,7 +89,7 @@ subtest 'Register Available Domain - With Privacy, Locking, Auto Renew' => sub {
         like( $domain->id, qr/^\d+$/, 'id looks numeric' );
         cmp_ok( $domain->name,                 'eq', $request->name,       'Correct name' );
         cmp_ok( $domain->status,               'eq', 'Registered',         'Correct status' );
-        cmp_ok( $domain->verification_status,  'eq', 'Pending Suspension', 'Correct verification_status' );
+        ok( ( grep { $domain->verification_status eq $_ } ( 'Pending Suspension', 'Verified' ) ), 'Correct verification_status' );
         cmp_ok( $domain->is_auto_renew,        '==', 1,                    'Correct is_auto_renew' );
         cmp_ok( $domain->is_locked,            '==', 1,                    'Correct is_locked' );
         cmp_ok( $domain->is_private,           '==', 1,                    'Correct is_private' );


### PR DESCRIPTION
In lib/WWW/eNom/Role/Command/Contact.pm
  Check if PartyID is defined

In t/role/command/domain/registration/01-register_domain.t
  Accept either Pending Suspension or Verified as verification_status